### PR TITLE
Improve message on parse error

### DIFF
--- a/calc.pl
+++ b/calc.pl
@@ -90,26 +90,15 @@ for ( $recce->read(\$input);
         $recce->lexeme_read('separ', $recce->pos, 0);
         $last_pos = $recce->pos;
         warn 'Semicolon inserted at ', $last_pos;
-    } else {
-        PARSE_ERROR($input, $recce->pos, $recce->terminals_expected);
+    }
+
+    else {
+        my $pos = $recce->pos;
+        my $context = substr($input, $pos);
+        my ($line, $col) = $recce->line_column;
+        my @expected = @{$recce->terminals_expected};
+
+        die "Parse error on line $line column $col at '$context', expecting: @expected\n";
     }
 }
 $recce->value;
-
-
-sub PARSE_ERROR {
-    my ($input, $pos, $expected) = @_;
-
-    my $line = 1+(substr($input,0,$pos) =~ tr/\n//);
-    my $eol = index($input,"\n",$pos);
-    $eol = length($input) if $eol < 0;
-
-    my $at;
-    if ($eol == $pos) {
-        $at = "end of line";
-    } else {
-        $at = "'" . substr($input, $pos, $eol - $pos) . "'";
-    }
-
-    die "Parse error on line $line at $at, expecting: @$expected\n";
-}

--- a/calc.pl
+++ b/calc.pl
@@ -15,7 +15,7 @@ Program    ::= Statement+                  action => none
 Statement  ::= Assign separ                action => none
              | Output separ                action => none
 Assign     ::= Var ('=') Expression        action => store
-Output     ::= print List                  action => show
+Output     ::= (print) List                action => show
 List       ::= Expression (',') List       action => concat
              | Expression
              | String (',') List           action => concat
@@ -64,7 +64,7 @@ my %vars;
 sub none        {}
 sub single      { $_[1] }
 sub numify      { 0 + $_[1] }
-sub show        { say $_[2] }
+sub show        { say $_[1] }
 sub concat      { $_[1] . $_[2] }
 sub multiply    { $_[1] * $_[2] }
 sub divide      { $_[1] / $_[2] }
@@ -100,7 +100,7 @@ $recce->value;
 sub PARSE_ERROR {
     my ($input, $pos, $expected) = @_;
 
-    my $line = 1+(substr($input,0,$pos) =~ tr/\n/\n/);
+    my $line = 1+(substr($input,0,$pos) =~ tr/\n//);
     my $eol = index($input,"\n",$pos);
     $eol = length($input) if $eol < 0;
 


### PR DESCRIPTION
Hello, forgive the unsolicited, drive-by, necromantic pull-request (all the evils), but I found your repo and was quite pleased to find a way to incorporate the use of `terminals_expected` with a higher-level interface of Marpa (I was doing something much uglier).

In my opinion, one of the better uses of `terminals_expected` is improving the quality of parse error messages, which is what this pull-request adds.


BEFORE:

    $ perl calc.pl '2+3'
    No lexeme found at 0 at calc.pl line 92.


AFTER:

    $ perl calc.pl '2+3'
    Parse error on line 1 at '2+3', expecting: print varname


NOTE: Any literal in the grammar (e.g., "('print')") will produce less than stellar error messages since they are given internal token names. That is why I moved "('print')" to its own token. I left the rest for illustration and to avoid needlessly expanding the code.

EXAMPLE OF BAD INLINE LITERALS (first three are probably internal names for '(', '"', and '='):

    $ perl calc.pl 'print'
    Parse error on line 1 at ';', expecting: [Lex-0] [Lex-10] [Lex-3] number varname


I see that this repo is for a presentation that you gave/give and error messages may not be the point of that talk, so feel free to drop this PR if you like. I was just so happy to find an example which fits in with my error processing (examples I've seen all show just `$grammar->parse()`) that I felt I should send a comment/patch showing just how easy it is with Marpa.

(LEGAL: Feel free to use this code however you like, patch submitted into the public domain or CC0)